### PR TITLE
Feature/1919/hosted content spread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/dockstore/dockstore-load-tester.svg?branch=master)](https://travis-ci.org/dockstore/dockstore-load-tester.svg?branch=master)
+
 # dockstore-load-tester
 Dockstore Load/Performance/Stress Tester
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can configure the following properties with `-D`, e.g., `-Dusers=50`:
 * maxResponseTimeMs -- if any API call takes longer than this, simulation will fail; default is 10,000, which is probably too low
 * successThreshold -- the precentage of calls that should pass; if less, the simulation fails; default is 95
 
-Regarding the last two items, the tests will still run to completion; there will 
+Regarding the last two items, the tests will still run to completion; there will a message at the end saying the tests failed.
 
 The default values are defined in the `<properties>` section of the pom.xml.
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <scala.version>2.12.7</scala.version>
         <encoding>UTF-8</encoding>
         <gatling-plugin.version>3.0.0</gatling-plugin.version>
-        <gatling.version>3.0.0</gatling.version>
+        <gatling.version>3.0.1.1</gatling.version>
         <scala-maven-plugin.version>3.3.1</scala-maven-plugin.version>
 
         <atOnce>true</atOnce>

--- a/src/test/resources/bodies/hosted/CreateHostedWdlWorkflow.json
+++ b/src/test/resources/bodies/hosted/CreateHostedWdlWorkflow.json
@@ -1,7 +1,0 @@
-[
-  {
-    "content": "task hello {\n  String pattern\n  File in\n\n  command {\n    egrep '${pattern}' '${in}'\n  }\n\n  runtime {\n    docker: \"broadinstitute/my_image\"\n  }\n\n  output {\n    Array[String] matches = read_lines(stdout())\n  }\n}\n\nworkflow wf {\n  call hello\n}",
-    "path": "/Dockstore.wdl",
-    "type": "DOCKSTORE_WDL"
-  }
-]

--- a/src/test/resources/bodies/hosted/HostedWdlWorkflow.json
+++ b/src/test/resources/bodies/hosted/HostedWdlWorkflow.json
@@ -1,0 +1,7 @@
+[
+  {
+    "content": "task hello {\n  String pattern\n  File in\n\n  command {\n    egrep '${pattern}' '${in}'\n  }\n\n  runtime {\n    docker: \"broadinstitute/my_image\"\n  }\n\n  output {\n    Array[String] matches = read_lines(stdout())\n  }\n}\n\nworkflow wf {\n  call hello\n}{{randomComments}}",
+    "path": "/Dockstore.wdl",
+    "type": "DOCKSTORE_WDL"
+  }
+]

--- a/src/test/resources/bodies/hosted/UpdateHostedWdlWorkflow.json
+++ b/src/test/resources/bodies/hosted/UpdateHostedWdlWorkflow.json
@@ -1,9 +1,0 @@
-[
-  {
-    "content": "task hello {\n  String pattern\n  File in\n\n  command {\n    egrep '${pattern}' '${in}'\n  }\n\n  runtime {\n    docker: \"broadinstitute/my_image\"\n  }\n\n  output {\n    Array[String] matches = read_lines(stdout())\n  }\n}\n\nworkflow wf {\n  call hello\n}\n",
-    "id": 3463052,
-    "path": "/Dockstore.wdl",
-    "type": "DOCKSTORE_WDL",
-    "verifiedBySource": {}
-  }
-]

--- a/src/test/scala/io/dockstore/CreateAndUpdateHostedWorkflow.scala
+++ b/src/test/scala/io/dockstore/CreateAndUpdateHostedWorkflow.scala
@@ -19,16 +19,23 @@ object CreateAndUpdateHostedWorkflow {
 
   def create =
     doIf(session => !session("token").as[String].equals(Requests.ANONOYMOUS)) {
+
+      val randomComments = "randomComments" // The Pebble variable in HostedWdlWorkflow.json
+
       feed(workflowNameFeeder)
         .exec(Workflow.createHosted("${workflowName}", "${token}", "wdl")
           .check(status in(200, 201)) // Should be 201, but https://github.com/ga4gh/dockstore/issues/1859
           .check(jsonPath("$.id").saveAs("id")))
 
-        .exec(Workflow.addFileToHostedWorkflow("${id}", "${token}", "bodies/hosted/CreateHostedWdlWorkflow.json")
+        .exec(session => session.set(randomComments, Utils.randomWdlComments))
+
+        .exec(Workflow.addFileToHostedWorkflow("${id}", "${token}", "bodies/hosted/HostedWdlWorkflow.json")
           .check(status is 200))
 
+        .exec(session => session.set(randomComments, Utils.randomWdlComments))
+
         // Save another revision
-        .exec(Workflow.addFileToHostedWorkflow("${id}", "${token}", "bodies/hosted/UpdateHostedWdlWorkflow.json")
+        .exec(Workflow.addFileToHostedWorkflow("${id}", "${token}", "bodies/hosted/HostedWdlWorkflow.json")
         .check(status is 200))
     }
 }

--- a/src/test/scala/io/dockstore/Requests.scala
+++ b/src/test/scala/io/dockstore/Requests.scala
@@ -168,7 +168,7 @@ object Requests {
         .patch(s"/workflows/hostedEntry/${id}")
         .headers(authHeader(token))
         .headers(Map("Content-type" -> "application/json"))
-        .body(RawFileBody(filename))
+        .body(PebbleFileBody(filename))
     }
 
     def downloadWorkflowAsZip(workflowId: String, version: String) = {

--- a/src/test/scala/io/dockstore/Utils.scala
+++ b/src/test/scala/io/dockstore/Utils.scala
@@ -2,7 +2,14 @@ package io.dockstore
 
 import java.net.URLEncoder
 
+import scala.util.Random
+
 object Utils {
+
+  private val AVERAGE_SIZE_OF_ENTRY = 12000 // Assume the average workflow is this size
+  private val COMMENT_LINE_LENGTH = 50 // An arbitrary value
+  private val AVERAGE_NUMBER_OF_COMMENTS = AVERAGE_SIZE_OF_ENTRY / COMMENT_LINE_LENGTH
+  private val ONE_STANDARD_DEVIATION = AVERAGE_NUMBER_OF_COMMENTS * .68
 
   def encode(element: String): String = {
     URLEncoder.encode(element)
@@ -10,5 +17,26 @@ object Utils {
 
   def encodeWorkflow(path: String): String = {
     URLEncoder.encode("#workflow/" + path)
+  }
+
+  /**
+    * The WDL template is trivial in size. Generate a random number of comments to make the final WDL
+    * larger. We assume the average workflow is AVERAGE_SIZE_OF_ENTRY bytes in length,
+    * so generate enough comments to make a standard distribution of comments around the mean of
+    * AVERAGE_SIZE_OF_ENTRY.
+    * @return
+    */
+  def randomWdlComments: String = {
+
+    def numberOfLinesToGenerate = {
+      // See https://www.javamex.com/tutorials/random_numbers/gaussian_distribution_2.shtml
+      Math.round(Random.nextGaussian() * ONE_STANDARD_DEVIATION + AVERAGE_NUMBER_OF_COMMENTS).intValue()
+    }
+
+    val sb = new StringBuilder
+    for (i <- 0 until numberOfLinesToGenerate) {
+      sb.append(s"\\n# ${Random.alphanumeric take COMMENT_LINE_LENGTH mkString}")
+    }
+    sb.mkString
   }
 }

--- a/src/test/scala/io/dockstore/Utils.scala
+++ b/src/test/scala/io/dockstore/Utils.scala
@@ -34,7 +34,7 @@ object Utils {
     }
 
     val sb = new StringBuilder
-    for (i <- 0 until numberOfLinesToGenerate) {
+    for (i <- 1 until numberOfLinesToGenerate) {
       sb.append(s"\\n# ${Random.alphanumeric take COMMENT_LINE_LENGTH mkString}")
     }
     sb.mkString

--- a/src/test/scala/io/dockstore/Utils.scala
+++ b/src/test/scala/io/dockstore/Utils.scala
@@ -24,7 +24,7 @@ object Utils {
     * larger. We assume the average workflow is AVERAGE_SIZE_OF_ENTRY bytes in length,
     * so generate enough comments to make a standard distribution of comments around the mean of
     * AVERAGE_SIZE_OF_ENTRY.
-    * @return
+    * @return a string of multiple comments separated by newline characters
     */
   def randomWdlComments: String = {
 


### PR DESCRIPTION
Generate hosted WDL entries with an average of 12,000 bytes in size.

The distribution of entries will be a standard bell curve.

Used Gatling's Pebble templating to insert the the randomly generated data.

There is a small WDL file template; add a random number of comments to it to fill it out.

Also:

* Upgrade to Gatling 3.0.1.1
* Finished sentence in README