### PR TITLE
Fix and improve publishing tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ You can configure the following properties with `-D`, e.g., `-DauthUsers=50`. De
 * baseUrl -- the Dockstore webservice endpoint to run the tests against; defaults to `http://localhost:8080`
 * scenario -- the name of the scenario to run; see DockstoreWebUser.scala for all available; defaults to `Everything`, which runs (almost) everything
 * maxResponseTimeMs -- if any API call takes longer than this, simulation will fail; default is 10,000, which is probably too high
-* successThreshold -- the precentage of calls that should pass; if less, the simulation fails; default is 95
+* successThreshold -- the percentage of calls that should pass; if less, the simulation fails; default is 95
+* percentToPublish -- the percentage of workflows created in the `HostedWorkflowCrud` scenario that will be published; the default is 25
 
 Regarding the last two items, the tests will still run to completion; if there is failure, there will a message so indicating at the end.
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <authUsers>50</authUsers>
         <anonUsers>50</anonUsers>
         <rampMinutes>5</rampMinutes>
+        <percentToPublish>25</percentToPublish>
         <maxResponseTimeMs>10000</maxResponseTimeMs>
         <successThreshold>95</successThreshold>
         <scenario>Everything</scenario>
@@ -115,6 +116,7 @@
                         <jvmArg>-DanonUsers=${anonUsers}</jvmArg>
                         <jvmArg>-DrampMinutes=${rampMinutes}</jvmArg>
                         <jvmArg>-Dscenario=${scenario}</jvmArg>
+                        <jvmArg>-DpercentToPublish=${percentToPublish}</jvmArg>
                     </jvmArgs>
                 </configuration>
             </plugin>

--- a/src/test/resources/bodies/hosted/HostedWdlWorkflow.json
+++ b/src/test/resources/bodies/hosted/HostedWdlWorkflow.json
@@ -1,6 +1,6 @@
 [
   {
-    "content": "task hello {\n  String pattern\n  File in\n\n  command {\n    egrep '${pattern}' '${in}'\n  }\n\n  runtime {\n    docker: \"broadinstitute/my_image\"\n  }\n\n  output {\n    Array[String] matches = read_lines(stdout())\n  }\n}\n\nworkflow wf {\n  call hello\n}{{randomComments}}",
+    "content": "task hello {\n  String pattern\n  File in\n\n  command {\n    egrep '${pattern}' '${in}'\n  }\n\n  runtime {\n    docker: \"broadinstitute/my_image\"\n  }\n\n  output {\n    Array[String] matches = read_lines(stdout())\n  }\n\n  meta {\n    author: \"{{username}}\"\n  }\n\n}\n\nworkflow wf {\n  call hello\n}\n{{randomComments}}",
     "path": "/Dockstore.wdl",
     "type": "DOCKSTORE_WDL"
   }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
 
 	<!-- uncomment and set to DEBUG to log all failing HTTP requests -->
 	<!-- uncomment and set to TRACE to log all HTTP requests -->
-	<!--<logger name="io.gatling.http.engine.response" level="TRACE" />-->
+	<logger name="io.gatling.http.engine.response" level="DEBUG" />
 
 	<root level="WARN">
 		<appender-ref ref="CONSOLE" />

--- a/src/test/scala/io/dockstore/CreateAndUpdateHostedWorkflow.scala
+++ b/src/test/scala/io/dockstore/CreateAndUpdateHostedWorkflow.scala
@@ -21,6 +21,8 @@ object CreateAndUpdateHostedWorkflow {
 
     val randomComments = "randomComments" // The Pebble variable in HostedWdlWorkflow.json
 
+    val percentToPublish: Double = System.getProperty("percentToPublish", "25").toDouble / 100
+
     feed(workflowNameFeeder)
       .exec(Workflow.createHosted("${workflowName}", "${token}", "wdl")
         .check(status in(200, 201)) // Should be 201, but https://github.com/ga4gh/dockstore/issues/1859
@@ -36,5 +38,12 @@ object CreateAndUpdateHostedWorkflow {
       // Save another revision
       .exec(Workflow.addFileToHostedWorkflow("${id}", "${token}", "bodies/hosted/HostedWdlWorkflow.json")
       .check(status is 200))
+
+      .doIf(s => math.random < percentToPublish) {
+
+        exec(session => session.set("publish", "true"))
+
+          .exec(Workflow.publishOrUnpublish("${id}", "${token}"))
+      }
   }
 }

--- a/src/test/scala/io/dockstore/HostedWorkflows.scala
+++ b/src/test/scala/io/dockstore/HostedWorkflows.scala
@@ -22,7 +22,7 @@ object HostedWorkflows {
       .exec(
         Workflow.getWorkflow("${id}", "${token}")
           .check(status is 200)
-          .check(jsonPath("$.is_published").transform(p => p == false).saveAs("publish"))
+          .check(jsonPath("$.is_published").transform(p => {p == "false"}).saveAs("publish"))
       )
 
       .exec(


### PR DESCRIPTION

ga4gh/dockstore#2023

Fix: In HostedWorkflows.scala, logic to toggle always determined
incorrectly workflow was published because was comparing against
`false` instead of `"false"`.

Improve: When creating hosted workflows, randomly publish a
configurable percentage of them, whose default value is 25 (percent).

Also:

* Add author in WDL to make elastic searches more interesting
* Log HTTP errors by default.