### PR TITLE
Add description to HTML and super-fast tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                 <artifactId>gatling-maven-plugin</artifactId>
                 <version>${gatling-plugin.version}</version>
                 <configuration>
+                    <runDescription>${authUsers} auth users, ${anonUsers} anon users, ramp minutes ${rampMinutes}, scenario ${scenario}, atOnce ${atOnce}</runDescription>
                     <jvmArgs>
                         <jvmArg>-DatOnce=${atOnce}</jvmArg>
                         <jvmArg>-DbaseUrl=${baseUrl}</jvmArg>

--- a/src/test/scala/io/dockstore/DockstoreWebUser.scala
+++ b/src/test/scala/io/dockstore/DockstoreWebUser.scala
@@ -37,6 +37,7 @@ class DockstoreWebUser extends Simulation {
     scenario("ToolsAndWorkflowsSearch").exec(ToolsPageSearch.search, WorkflowsPageSearch.search),
     scenario("ToolsSearch").exec(ToolsPageSearch.search),
     scenario("WorkflowsSearch").feed(tokenFeeder).exec(WorkflowsPageSearch.search),
+    scenario("NoDbApis").exec(NoDbApis.simple),
 
     scenario(everythingScenario).feed(tokenFeeder).exec(
       HomePage.open,

--- a/src/test/scala/io/dockstore/NoDbApis.scala
+++ b/src/test/scala/io/dockstore/NoDbApis.scala
@@ -1,0 +1,15 @@
+package io.dockstore
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+object NoDbApis {
+
+  val simple = exec(
+    Requests.Ga4gh2.getMetadata
+      .check(status is 200)
+  ).exec(
+    Requests.MetaData.getSourceControlList
+      .check(status is 200)
+  )
+}


### PR DESCRIPTION

* Add a description to the generated HTML report
* Create a very simple test that calls APIs whose implementation
doesn't require any database access; use it to determine how
many requests can simultaneously be handled if you remove
database access from the equation.