### PR TITLE
Invoke new secondary endpoint

### DIFF
--- a/src/test/scala/io/dockstore/Requests.scala
+++ b/src/test/scala/io/dockstore/Requests.scala
@@ -162,7 +162,7 @@ object Requests {
 
     def getSecondaryWdl(workflowId: String, version: String) = {
       http("Get secondary wdl")
-        .get(s"/workflows/${workflowId}/secondaryWdl?tag=${version}")
+        .get(s"/workflows/${workflowId}/secondaryDescriptors?tag=${version}&language=wdl")
 
     }
 

--- a/src/test/scala/io/dockstore/WorkflowsPageSearch.scala
+++ b/src/test/scala/io/dockstore/WorkflowsPageSearch.scala
@@ -57,7 +57,7 @@ object WorkflowsPageSearch {
           Ga4gh2.getWdlFiles("${fullWorkflowPath}", "${version}")
             .check(status in(200, 204))
         ))
-    .doIfEquals("${descriptorType}", "wdl") {
+    .doIfEquals("${descriptorType}", "WDL") {
       exec(
         Workflow.getSecondaryWdl("${id}", "${version}")
       )


### PR DESCRIPTION
dockstore/dockstore#2929

secondaryWdl endpoint has been replaced with secondaryDescriptors.

Also, /workflows/published is now returning the descriptorType
in uppercase, so adjust accordingly.