### PR TITLE
update performance test for 1.9

### DIFF
--- a/src/test/resources/bodies/search/loadSearchPageCall1-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall1-1.9.0.json
@@ -1,0 +1,144 @@
+{
+  "size": 201,
+  "_source": false,
+  "query": {
+    "match_all": {}
+  },
+  "aggs": {
+    "_type": {
+      "terms": {
+        "field": "_type",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "descriptorType": {
+      "terms": {
+        "field": "descriptorType",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "registry": {
+      "terms": {
+        "field": "registry",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "source_control_provider.keyword": {
+      "terms": {
+        "field": "source_control_provider.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "input_file_formats.value.keyword": {
+      "terms": {
+        "field": "input_file_formats.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "output_file_formats.value.keyword": {
+      "terms": {
+        "field": "output_file_formats.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "private_access": {
+      "terms": {
+        "field": "private_access",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "verified": {
+      "terms": {
+        "field": "verified",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "author": {
+      "terms": {
+        "field": "author",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "namespace": {
+      "terms": {
+        "field": "namespace",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "labels.value.keyword": {
+      "terms": {
+        "field": "labels.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "workflowVersions.verifiedSources.keyword": {
+      "terms": {
+        "field": "workflowVersions.verifiedSources.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "has_checker": {
+      "terms": {
+        "field": "has_checker",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "organization": {
+      "terms": {
+        "field": "organization",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "verified_platforms.keyword": {
+      "terms": {
+        "field": "verified_platforms.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/loadSearchPageCall2-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall2-1.9.0.json
@@ -1,0 +1,22 @@
+{
+  "size": 201,
+  "_source": {
+    "excludes": [
+      "*.content",
+      "*.sourceFiles",
+      "description",
+      "users",
+      "workflowVersions.dirtyBit",
+      "workflowVersions.hidden",
+      "workflowVersions.last_modified",
+      "workflowVersions.name",
+      "workflowVersions.valid",
+      "workflowVersions.workflow_path",
+      "workflowVersions.workingDirectory",
+      "workflowVersions.reference"
+    ]
+  },
+  "query": {
+    "match_all": {}
+  }
+}

--- a/src/test/resources/bodies/search/loadSearchPageCall3-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall3-1.9.0.json
@@ -1,0 +1,17 @@
+{
+  "size": 20,
+  "_source": false,
+  "query": {
+    "match": {
+      "_type": "tool"
+    }
+  },
+  "aggs": {
+    "tagcloud": {
+      "significant_terms": {
+        "field": "description",
+        "size": 20
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/loadSearchPageCall4-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall4-1.9.0.json
@@ -1,0 +1,17 @@
+{
+  "size": 20,
+  "_source": false,
+  "query": {
+    "match": {
+      "_type": "workflow"
+    }
+  },
+  "aggs": {
+    "tagcloud": {
+      "significant_terms": {
+        "field": "description",
+        "size": 20
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/loadSearchPageCall5-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall5-1.9.0.json
@@ -1,0 +1,144 @@
+{
+  "size": 201,
+  "_source": false,
+  "query": {
+    "match_all": {}
+  },
+  "aggs": {
+    "_type": {
+      "terms": {
+        "field": "_type",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "descriptorType": {
+      "terms": {
+        "field": "descriptorType",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "registry": {
+      "terms": {
+        "field": "registry",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "source_control_provider.keyword": {
+      "terms": {
+        "field": "source_control_provider.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "input_file_formats.value.keyword": {
+      "terms": {
+        "field": "input_file_formats.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "output_file_formats.value.keyword": {
+      "terms": {
+        "field": "output_file_formats.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "private_access": {
+      "terms": {
+        "field": "private_access",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "verified": {
+      "terms": {
+        "field": "verified",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "author": {
+      "terms": {
+        "field": "author",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "namespace": {
+      "terms": {
+        "field": "namespace",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "labels.value.keyword": {
+      "terms": {
+        "field": "labels.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "workflowVersions.verifiedSources.keyword": {
+      "terms": {
+        "field": "workflowVersions.verifiedSources.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "has_checker": {
+      "terms": {
+        "field": "has_checker",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "organization": {
+      "terms": {
+        "field": "organization",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "verified_platforms.keyword": {
+      "terms": {
+        "field": "verified_platforms.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/loadSearchPageCall6-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall6-1.9.0.json
@@ -1,0 +1,22 @@
+{
+  "size": 201,
+  "_source": {
+    "excludes": [
+      "*.content",
+      "*.sourceFiles",
+      "description",
+      "users",
+      "workflowVersions.dirtyBit",
+      "workflowVersions.hidden",
+      "workflowVersions.last_modified",
+      "workflowVersions.name",
+      "workflowVersions.valid",
+      "workflowVersions.workflow_path",
+      "workflowVersions.workingDirectory",
+      "workflowVersions.reference"
+    ]
+  },
+  "query": {
+    "match_all": {}
+  }
+}

--- a/src/test/resources/bodies/search/loadSearchPageCall7-1.9.0.json
+++ b/src/test/resources/bodies/search/loadSearchPageCall7-1.9.0.json
@@ -1,0 +1,17 @@
+{
+  "size": 0,
+  "aggs": {
+    "autocomplete": {
+      "terms": {
+        "field": "description",
+        "size": 4,
+        "order": {
+          "_count": "desc"
+        },
+        "include": {
+          "pattern": ".*"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/performSearches-1.9.0/searchRandomTerm1.json
+++ b/src/test/resources/bodies/search/performSearches-1.9.0/searchRandomTerm1.json
@@ -1,0 +1,214 @@
+{
+  "size": 201,
+  "_source": false,
+  "query": {
+    "bool": {
+      "filter": {
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "workflowVersions.sourceFiles.content": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "tags.sourceFiles.content": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "description": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "labels": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "author": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "tool_path": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "full_workflow_path": "${searchTerm}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "aggs": {
+    "_type": {
+      "terms": {
+        "field": "_type",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "descriptorType": {
+      "terms": {
+        "field": "descriptorType",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "registry": {
+      "terms": {
+        "field": "registry",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "source_control_provider.keyword": {
+      "terms": {
+        "field": "source_control_provider.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "input_file_formats.value.keyword": {
+      "terms": {
+        "field": "input_file_formats.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "output_file_formats.value.keyword": {
+      "terms": {
+        "field": "output_file_formats.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "private_access": {
+      "terms": {
+        "field": "private_access",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "verified": {
+      "terms": {
+        "field": "verified",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "author": {
+      "terms": {
+        "field": "author",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "namespace": {
+      "terms": {
+        "field": "namespace",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "labels.value.keyword": {
+      "terms": {
+        "field": "labels.value.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "workflowVersions.verifiedSources.keyword": {
+      "terms": {
+        "field": "workflowVersions.verifiedSources.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "has_checker": {
+      "terms": {
+        "field": "has_checker",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "organization": {
+      "terms": {
+        "field": "organization",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    },
+    "verified_platforms.keyword": {
+      "terms": {
+        "field": "verified_platforms.keyword",
+        "size": 10000,
+        "order": {
+          "_count": "desc"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/performSearches-1.9.0/searchRandomTerm2.json
+++ b/src/test/resources/bodies/search/performSearches-1.9.0/searchRandomTerm2.json
@@ -1,0 +1,92 @@
+{
+  "size": 201,
+  "_source": {
+    "excludes": [
+      "*.content",
+      "*.sourceFiles",
+      "description",
+      "users",
+      "workflowVersions.dirtyBit",
+      "workflowVersions.hidden",
+      "workflowVersions.last_modified",
+      "workflowVersions.name",
+      "workflowVersions.valid",
+      "workflowVersions.workflow_path",
+      "workflowVersions.workingDirectory",
+      "workflowVersions.reference"
+    ]
+  },
+  "query": {
+    "bool": {
+      "filter": {
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "workflowVersions.sourceFiles.content": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "tags.sourceFiles.content": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "description": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "labels": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "author": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "tool_path": "${searchTerm}"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "filter": {
+                  "match_phrase": {
+                    "full_workflow_path": "${searchTerm}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/bodies/search/performSearches-1.9.0/searchRandomTerm3.json
+++ b/src/test/resources/bodies/search/performSearches-1.9.0/searchRandomTerm3.json
@@ -1,0 +1,17 @@
+{
+  "size": 0,
+  "aggs": {
+    "autocomplete": {
+      "terms": {
+        "field": "description",
+        "size": 4,
+        "order": {
+          "_count": "desc"
+        },
+        "include": {
+          "pattern": "${searchTerm}.*"
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/io/dockstore/DockstoreWebUser.scala
+++ b/src/test/scala/io/dockstore/DockstoreWebUser.scala
@@ -1,5 +1,7 @@
 package io.dockstore
 
+import io.dockstore
+import io.dockstore.release_1_9.{LoggedInHomepage, LoggedOutHomepage, Organizations, SearchPage}
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ScenarioBuilder
 
@@ -25,6 +27,10 @@ class DockstoreWebUser extends Simulation {
 
   private val anonymousUsersScenario = "AnonymousUsers"
 
+  private val loggedInUserFlow_1_9 = "LoggedIn_1.9"
+
+  private val loggedOutUserFlow_1_9 = "LoggedOut_1_9"
+
   val scenarios = Array(
     scenario("Account").feed(tokenFeeder).exec(Accounts.accountsPage),
     scenario("Home").exec(HomePage.open),
@@ -40,6 +46,10 @@ class DockstoreWebUser extends Simulation {
     scenario("NoDbApis").exec(NoDbApis.simple),
     scenario("TRS").exec(TRS.searchAndDrillDown),
     scenario("Metadata").exec(Metadata.go),
+    scenario("LoggedOutHomePage1.9.0").exec(LoggedOutHomepage.loggedOutHomepage),
+    scenario("LoggedInHomePage1.9.0").feed(tokenFeeder).exec(LoggedInHomepage.loggedInHomepage),
+    scenario("Organizations1.9.0").feed(tokenFeeder).exec(Organizations.organizations),
+    scenario("SearchPage1.9.0").exec(io.dockstore.release_1_9.SearchPage.search),
 
     scenario(everythingScenario).feed(tokenFeeder).exec(
       HomePage.open,
@@ -60,8 +70,31 @@ class DockstoreWebUser extends Simulation {
       SearchPage.search,
       TRS.searchAndDrillDown,
       Metadata.go
-    )
+    ),
 
+    scenario(loggedInUserFlow_1_9).feed(tokenFeeder).exec(
+      LoggedInHomepage.loggedInHomepage,
+      Accounts.accountsPage,
+      io.dockstore.release_1_9.SearchPage.search,
+      Organizations.organizations,
+      CreateAndUpdateHostedWorkflow.create,
+      HostedWorkflows.fetchRandomAndTogglePublish,
+      MyWorkflows.myWorkflows,
+      StarredToolsAndWorkflows.page
+    ),
+
+    scenario(loggedOutUserFlow_1_9).exec(
+      LoggedOutHomepage.loggedOutHomepage,
+      io.dockstore.release_1_9.SearchPage.search,
+      TRS.searchAndDrillDown,
+      Metadata.go
+    ),
+
+    scenario("jamboree").feed(tokenFeeder).exec(
+      LoggedInHomepage.loggedInHomepage,
+      io.dockstore.release_1_9.SearchPage.search,
+      Organizations.organizations,
+    )
   )
 
   private def getAnonymousScenario = {

--- a/src/test/scala/io/dockstore/DockstoreWebUser.scala
+++ b/src/test/scala/io/dockstore/DockstoreWebUser.scala
@@ -91,7 +91,7 @@ class DockstoreWebUser extends Simulation {
     ),
 
     scenario("jamboree").feed(tokenFeeder).exec(
-      LoggedInHomepage.loggedInHomepage,
+      LoggedOutHomepage.loggedOutHomepage,
       io.dockstore.release_1_9.SearchPage.search,
       Organizations.organizations,
     )

--- a/src/test/scala/io/dockstore/Requests.scala
+++ b/src/test/scala/io/dockstore/Requests.scala
@@ -475,6 +475,42 @@ object Requests {
         .headers(authHeader(token))
     }
 
+    def getUserEntries(token: String) = {
+      http("Get all of the entries for a user, sorted by most recently updated.")
+        .get("/users/users/entries")
+        .queryParam("count", 10)
+        .headers(authHeader(token))
+    }
+
+    def getFilteredUserEntries(token: String, filter: String) = {
+      http("Get all of the entries for a user, sorted by most recently updated.")
+        .get("/users/users/entries")
+        .queryParam("count", 10)
+        .queryParam("filter", filter)
+        .headers(authHeader(token))
+    }
+
+    def getUserDockstoreOrganizations(token: String) = {
+      http("Get all of the Dockstore organizations for a user, sorted by most recently updated.")
+        .get("/users/users/organizations")
+        .queryParam("count", 10)
+        .headers(authHeader(token))
+    }
+
+    def getFilteredUserDockstoreOrganizations(token: String, filter: String) = {
+      http("Get all of the Dockstore organizations for a user, sorted by most recently updated.")
+        .get("/users/users/organizations")
+        .queryParam("count", 10)
+        .queryParam("filter", filter)
+        .headers(authHeader(token))
+    }
+
+    def getUserDockstoreMemberships(token: String) = {
+      http("Get the logged-in user's memberships.")
+        .get("/users/user/memberships")
+        .headers(authHeader(token))
+    }
+
     /*
         "/users/updateUserMetadata": {
     "/users/{userId}": {
@@ -492,6 +528,78 @@ object Requests {
     "/users/user/updateUserMetadata": {
 
      */
+  }
+
+  object Organization {
+    def getApprovedOrganizations() = {
+      http("Get list of approved organizations")
+        .get("/organizations")
+    }
+
+    def getOrganizationByName(name: String, token: String) = {
+      http("Retrieve an organization by name")
+        .get(s"/organizations/name/${name}")
+        .headers(authHeader(token))
+    }
+
+    def getOrganizationById(orgId: Long, token: String) = {
+      http("Retrieve an organization by ID")
+        .get(s"/organizations/${orgId}")
+        .headers(authHeader(token))
+    }
+
+    def getOrganizationMembers(orgId: Long, token: String) = {
+      http("Retrieve all members for an organization.")
+        .get(s"/organizations/${orgId}/members")
+        .headers(authHeader(token))
+    }
+
+    def getCollectionsFromOrganization(orgId: Long, token: String) = {
+      http("Retrieve all collections for an organization.")
+        .get(s"/organizations/${orgId}/collections")
+        .headers(authHeader(token))
+    }
+
+    def getOrganizationEvents(orgId: Long, token: String) = {
+      http("getOrganizationEvents")
+        .get(s"/organizations/${orgId}/events")
+        .queryParam("offset", 0)
+        .queryParam("limit",  30)
+        .headers(authHeader(token))
+    }
+
+    def getStarredUsersForApprovedOrganization(orgId: Long, token: String) = {
+      http("Return list of users who starred the given approved organization")
+        .get(s"/organizations/${orgId}/starredUsers")
+    }
+
+    def getCollectionByName(orgName: String, collectionName: String, token: String) = {
+      http("Retrieve a collection by name. Supports optional authentication.")
+        .get(s"/organizations/${orgName}/collections/${collectionName}/name")
+        .headers(authHeader(token))
+    }
+
+    def getAllOrganizations(token: String) = {
+      http("List all organizations, regardless of organization status. Admin/curator only.")
+        .get("/organizations/all")
+        .queryParam("type", "pending")
+    }
+  }
+
+  object Notification {
+    def getActiveNotifications() = {
+      http("Return all active notifications")
+        .get("/curation/notifications")
+    }
+  }
+
+  object Event {
+    def getEvents(token: String) = {
+      http("Get events based on filters.")
+        .get("/events")
+        .queryParam("event_search_type", "ALL_STARRED")
+        .headers(authHeader(token))
+    }
   }
 
 }

--- a/src/test/scala/io/dockstore/release_1_9/LoggedInHomepage.scala
+++ b/src/test/scala/io/dockstore/release_1_9/LoggedInHomepage.scala
@@ -41,10 +41,6 @@ object LoggedInHomepage {
       .check(status is 200)
   )
       .exec(
-    Event.getEvents("${token}")
-      .check(status is 200)
-  )
-      .exec(
     User.getUserEntries("${token}")
       .check(status is 200)
   )

--- a/src/test/scala/io/dockstore/release_1_9/LoggedInHomepage.scala
+++ b/src/test/scala/io/dockstore/release_1_9/LoggedInHomepage.scala
@@ -1,0 +1,67 @@
+package io.dockstore.release_1_9
+
+import io.dockstore.Requests.{Event, Ga4gh2, MetaData, Notification, Organization, User}
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+/**
+  * Simulates a Dockstore user visiting the logged in homepage and performing a search through their entries and organizations. Notifications
+  * gets called twice on homepage.
+  */
+object LoggedInHomepage {
+
+  val loggedInHomepage =
+    exec(
+      User.getUser("${token}")
+        .check(status is 200)
+        .check(jsonPath("$.id").saveAs("userId"))
+    )
+      .exec(
+    Notification.getActiveNotifications()
+      .check(status is 200)
+  )
+      .exec(
+    Ga4gh2.getMetadata
+      .check(status is 200)
+  )
+      .exec(
+    MetaData.getDescriptorLanguageList
+      .check(status is 200)
+  )
+      .exec(
+    User.getTokens("${userId}", "${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Notification.getActiveNotifications()
+      .check(status is 200)
+  )
+      .exec(
+    Event.getEvents("${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Event.getEvents("${token}")
+      .check(status is 200)
+  )
+      .exec(
+    User.getUserEntries("${token}")
+      .check(status is 200)
+  )
+      .exec(
+    User.getUserDockstoreOrganizations("${token}")
+      .check(status is 200)
+  )
+      .exec(
+    User.getUserDockstoreMemberships("${token}")
+      .check(status is 200)
+  )
+      .pause(2)
+      .exec(
+    User.getFilteredUserEntries("${token}", "foo")
+      .check(status is 200)
+  )
+      .exec(
+    User.getFilteredUserDockstoreOrganizations("${token}", "foo")
+  )
+}

--- a/src/test/scala/io/dockstore/release_1_9/LoggedOutHomepage.scala
+++ b/src/test/scala/io/dockstore/release_1_9/LoggedOutHomepage.scala
@@ -1,0 +1,25 @@
+package io.dockstore.release_1_9
+
+import io.dockstore.Requests._
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+/**
+  * Simulates a Dockstore user visiting the logged out homepage
+  */
+object LoggedOutHomepage {
+
+  val loggedOutHomepage =
+  exec(
+    Notification.getActiveNotifications()
+      .check(status is 200)
+  )
+  exec(
+    Ga4gh2.getMetadata
+      .check(status is 200)
+  )
+  exec(
+    MetaData.getDescriptorLanguageList
+      .check(status is 200)
+  )
+}

--- a/src/test/scala/io/dockstore/release_1_9/Organizations.scala
+++ b/src/test/scala/io/dockstore/release_1_9/Organizations.scala
@@ -1,0 +1,54 @@
+package io.dockstore.release_1_9
+
+import io.dockstore.Requests._
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+import scala.util.Random
+
+/**
+  * Simulates a Dockstore user visiting organization and collection pages. Assumes the db that has the orgs and collections listed below.
+  * Chose the broad because it's the most popular and causes us the most problems...
+  */
+object Organizations {
+
+  // Hope to make more random, but for now pick the worst case scenario: Looking at the broad org and gatk collection
+  val organizationList = Array("BroadInstitute", "PCAWG")
+  val broadInstituteCollections = Array("GATKWorkflows", "pgs")
+  val pcawgCollections = Array("PCAWG")
+  var orgName = "BroadInstitute"
+
+  var orgId = 16
+  var collectionName = "GATKWorkflows"
+
+  val organizations =
+    exec(
+      Organization.getApprovedOrganizations()
+        .check(status is 200)
+    )
+      .pause(2)
+      .exec(
+    Organization.getOrganizationByName(orgName, "${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Organization.getOrganizationMembers(orgId,"${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Organization.getCollectionsFromOrganization(orgId, "${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Organization.getOrganizationEvents(orgId, "${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Organization.getStarredUsersForApprovedOrganization(orgId, "${token}")
+      .check(status is 200)
+  )
+      .exec(
+    Organization.getCollectionByName(orgName, collectionName, "${token}")
+      .check(status is 200)
+  )
+}

--- a/src/test/scala/io/dockstore/release_1_9/Organizations.scala
+++ b/src/test/scala/io/dockstore/release_1_9/Organizations.scala
@@ -16,10 +16,10 @@ object Organizations {
   val organizationList = Array("BroadInstitute", "PCAWG")
   val broadInstituteCollections = Array("GATKWorkflows", "pgs")
   val pcawgCollections = Array("PCAWG")
-  var orgName = "BroadInstitute"
+  val orgName = "BroadInstitute"
 
-  var orgId = 16
-  var collectionName = "GATKWorkflows"
+  val orgId = 16
+  val collectionName = "GATKWorkflows"
 
   val organizations =
     exec(

--- a/src/test/scala/io/dockstore/release_1_9/SearchPage.scala
+++ b/src/test/scala/io/dockstore/release_1_9/SearchPage.scala
@@ -1,0 +1,86 @@
+package io.dockstore.release_1_9
+
+import io.dockstore.Requests._
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+/**
+  * Simulates a Dockstore user visiting the search page and performing one search request
+  *
+  */
+object SearchPage {
+
+  private val searchPath = "/api/ga4gh/v2/extended/tools/entry/_search"
+
+  val search = {
+    val r = scala.util.Random
+    val searchIndex = r.nextInt(3)
+    val searchTermFiles = Array("searchPcawg", "searchGatk", "searchRandomTerm")
+
+    // Search page does 7 calls on page load
+    exec(
+      http("Load Search Page Call 1")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall1-1.9.0.json")).asJson
+        .check(status is 200)
+        .check(jsonPath("$['aggregations']['labels.value.keyword']['buckets'][*]['key']").findRandom.saveAs("searchTerm")
+        )
+    )
+      .exec(
+      http("Load Search Page Call 2")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall2-1.9.0.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Load Search Page Call 3")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall3-1.9.0.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Load Search Page Call 4")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall4-1.9.0.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Load Search Page Call 5")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall5-1.9.0.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Load Search Page Call 6")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall6-1.9.0.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Load Search Page Call 7")
+        .post(searchPath)
+        .body(RawFileBody("bodies/search/loadSearchPageCall7-1.9.0.json")).asJson
+        .check(status is 200)
+    )
+      .pause(2)
+      .exec(
+      http("Search for random term Call 1")
+        .post(searchPath)
+        .body(ElFileBody("bodies/search/performSearches-1.9.0/searchRandomTerm1.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Search for random term Call 2")
+        .post(searchPath)
+        .body(ElFileBody("bodies/search/performSearches-1.9.0/searchRandomTerm2.json")).asJson
+        .check(status is 200)
+    )
+      .exec(
+      http("Search for random term Call 3")
+        .post(searchPath)
+        .body(ElFileBody("bodies/search/performSearches-1.9.0/searchRandomTerm3.json")).asJson
+        .check(status is 200)
+    )
+  }
+
+}


### PR DESCRIPTION
dockstore/dockstore#3483
Created scenarios for the homepages and organization and collection pages. Also created one for the search since the calls performed on load and per each search is different now.

The search page will do a search on a random term each time and the org will always look at the broad and gatk workflows.